### PR TITLE
Add user audit filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -296,12 +296,20 @@ def registration_approval():
     action_type = request.args.get('action_type', '').strip()
     date_from = request.args.get('date_from', '').strip()
     date_to = request.args.get('date_to', '').strip()
+    filter_user_id = request.args.get('user_id', type=int)
+    if filter_user_id is None:
+        filter_user_id = request.args.get('target_id', type=int)
 
     actions_query = ticket_db.query(AuditLog).filter(AuditLog.entity_type.in_(['user', 'ticket']))
     if actor_id:
         actions_query = actions_query.filter(AuditLog.actor_id == actor_id)
     if action_type:
         actions_query = actions_query.filter(AuditLog.action_type == action_type)
+    if filter_user_id:
+        actions_query = actions_query.filter(
+            AuditLog.entity_id == str(filter_user_id),
+            AuditLog.entity_type == 'user'
+        )
     if date_from:
         from_dt = datetime.strptime(date_from, '%Y-%m-%d')
         actions_query = actions_query.filter(AuditLog.timestamp >= from_dt)
@@ -328,7 +336,8 @@ def registration_approval():
             'actor_id': actor_id,
             'action_type': action_type,
             'date_from': date_from,
-            'date_to': date_to
+            'date_to': date_to,
+            'user_id': filter_user_id
         }
     )
 

--- a/templates/registration_approval.html
+++ b/templates/registration_approval.html
@@ -215,7 +215,7 @@
         <!-- Форма фильтрации -->
         <form method="get" class="row g-3 mb-3">
             <input type="hidden" name="active_tab" value="history">
-            <div class="col-md-3">
+            <div class="col-md-2">
                 <label for="actor_id" class="form-label">Пользователь</label>
                 <select class="form-select" id="actor_id" name="actor_id">
                     <option value="">Все</option>
@@ -224,7 +224,7 @@
                     {% endfor %}
                 </select>
             </div>
-            <div class="col-md-3">
+            <div class="col-md-2">
                 <label for="action_type" class="form-label">Действие</label>
                 <select class="form-select" id="action_type" name="action_type">
                     <option value="">Все</option>
@@ -232,6 +232,10 @@
                         <option value="{{ atype }}" {% if filter_params.action_type == atype %}selected{% endif %}>{{ action_type_labels.get(atype, atype) }}</option>
                     {% endfor %}
                 </select>
+            </div>
+            <div class="col-md-2">
+                <label for="user_id" class="form-label">ID пользователя</label>
+                <input type="number" class="form-control" id="user_id" name="user_id" value="{{ filter_params.user_id }}">
             </div>
             <div class="col-md-2">
                 <label for="date_from" class="form-label">Дата с</label>


### PR DESCRIPTION
## Summary
- allow filtering AuditLog entries by user id in `registration_approval`
- surface `user_id` filter in the registration approval page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846de2ec0b0832f963137c734305e77